### PR TITLE
Support new alternative Intel map URLs

### DIFF
--- a/IngressMaxFields.user.js
+++ b/IngressMaxFields.user.js
@@ -7,10 +7,14 @@
 // @updateURL http://github.com/itayo/IITC-Ingress-Maxfields-Exporter/raw/master/IngressMaxFields.user.js
 // @downloadURL http://github.com/itayo/IITC-Ingress-Maxfields-Exporter/raw/master/IngressMaxFields.user.js
 // @description Exports portals in the format for http://www.ingress-maxfield.com/ and allow direct transfer to site
-// @include https://www.ingress.com/intel*
-// @include http://www.ingress.com/intel*
-// @match https://www.ingress.com/intel*
-// @match http://www.ingress.com/intel*
+// @include        https://*.ingress.com/intel*
+// @include        http://*.ingress.com/intel*
+// @match          https://*.ingress.com/intel*
+// @match          http://*.ingress.com/intel*
+// @include        https://*.ingress.com/mission/*
+// @include        http://*.ingress.com/mission/*
+// @match          https://*.ingress.com/mission/*
+// @match          http://*.ingress.com/mission/*
 // @grant none
 // ==/UserScript==
 /*global $:false */


### PR DESCRIPTION
Ensure this plugin loads when IITC loads, for instance when loading from `ingress.com/intel` or Mission permalinks (never tested the second part, I followed the code).

This follows the IITC updates in these commits:
iitc-project/ingress-intel-total-conversion@32e455f4e8beba65d9072566dddf20ca4133efb6
iitc-project/ingress-intel-total-conversion@eba7d388a0af1163f46221edaba3aeab77b6d7f8

Caveat: double-test for typos, I've edited the script locally with TamperMonkey, tested it minimally, and pasted the changes here via GitHub. And I didn't double-check the change much, beyond digging down the original IITC changes.

As explained [on the community](https://plus.google.com/105383756361375410867/posts/WPm9tu6ZY7C)
for the first fix (not for the mission links):

> Why does IITC/[third-party plugin X] not load in Chrome?
> tl;dr: Quick fix: ensure you visit www.ingress.com/intel instead of ingress.com/intel.
> ingress.com no longer redirects to www.ingress.com, so the URL matching patterns
> broke. Third-party plugins must update their @include/@match patterns to be
> "*.ingress.com" instead of just "www.ingress.com" to fix this.
